### PR TITLE
使用 --auto 参数自动执行任务(close #14)

### DIFF
--- a/app/view/main_window.py
+++ b/app/view/main_window.py
@@ -5,6 +5,7 @@ import re
 import subprocess
 import threading
 import time
+import sys
 
 import cv2
 import numpy as np
@@ -89,6 +90,9 @@ class MainWindow(MSFluentWindow):
             # update_thread = threading.Thread(target=self.check_update)
             # update_thread.start()
             self.check_update()
+
+        if '--auto' in sys.argv:
+            self.homeInterface.on_start_button_click()
 
     def open_game_directly(self):
         """直接启动游戏"""


### PR DESCRIPTION
# Story 助手启动时自动执行任务

## 状态：Ready for review

## 故事

**作为一个** 尘白助手用户
**我希望** 有一种办法可以在助手启动时自动执行日常任务然后关闭游戏和助手
**以便** 我可以通过 Windows 的计划任务自动处理收菜事宜

## 验收标准（ACs）

- [x] 使用 `python.exe ./SAA.py --auto` 能按照预期工作
- [ ] 打包为 exe 后使用 `SAA.exe --auto` 能按照预期工作

## 开发注意事项

使用 `sys.argv` 获取启动参数

（改动太简单了，其余啰嗦部分略）