### PR TITLE
修复开机自启无法生效的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__/
 nuitka-crash-report.xml
 .venv/
 *.pyc
+saa.cmd

--- a/app/view/setting_interface.py
+++ b/app/view/setting_interface.py
@@ -298,7 +298,7 @@ class SettingInterface(ScrollArea):
         try:
             # 获取应用程序所在目录
             app_dir = os.path.dirname(self.app_path)
-            cmd_file_path = os.path.join(app_dir, "saa.cmd")
+            cmd_file_path = os.path.join(app_dir, "saa_startup.cmd")
 
             # 创建 cmd 文件内容
             cmd_content = f'@echo off\ncd "{app_dir}"\nstart "" "{self.app_path}"'
@@ -353,7 +353,7 @@ class SettingInterface(ScrollArea):
 
             # 删除 cmd 文件
             app_dir = os.path.dirname(self.app_path)
-            cmd_file_path = os.path.join(app_dir, "saa.cmd")
+            cmd_file_path = os.path.join(app_dir, "saa_startup.cmd")
             if os.path.exists(cmd_file_path):
                 os.remove(cmd_file_path)
 


### PR DESCRIPTION
原因：
--
如果试图直接在后台拉起 exe，会有 cwd 或者 UAC 或者别的什么的问题导致无法直接拉起。

所以使用一个 cmd 文件指定 cwd 参数后通过 start 命令拉起 exe。

但这个办法一来会有黑框，二来仍未解决 UAC 的问题。

故将此 cmd 文件通过计划任务声明最高权限（UAC）拉起，那么直接执行任务时不会弹黑框。